### PR TITLE
set cron to 6pm PDT

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron",
-      "schedule": "0 7 * * *"
+      "schedule": "0 1 * * *"
     }
   ]
 }


### PR DESCRIPTION
Interest cron job is failing in most cases. It runs at 12am PDT, which makes it difficult to monitor (due to poor logging, which is a bigger issue). 

This changes the cron to be more observable while troubleshooting. 